### PR TITLE
bump dependency on propelauth-py to 3.2.0, bump version to 2.2.0

### DIFF
--- a/propelauth_fastapi/__init__.py
+++ b/propelauth_fastapi/__init__.py
@@ -179,6 +179,10 @@ FastAPIAuth = namedtuple(
         "resend_email_confirmation",
         "fetch_pending_invites",
         "logout_all_user_sessions",
+        "fetch_saml_sp_metadata",
+        "set_saml_idp_metadata",
+        "saml_go_live",
+        "delete_saml_connection",
     ],
 )
 
@@ -258,4 +262,8 @@ def init_auth(
         fetch_pending_invites=auth.fetch_pending_invites,
         logout_all_user_sessions=auth.logout_all_user_sessions,
         revoke_pending_org_invite=auth.revoke_pending_org_invite,
+        fetch_saml_sp_metadata=auth.fetch_saml_sp_metadata,
+        set_saml_idp_metadata=auth.set_saml_idp_metadata,
+        saml_go_live=auth.saml_go_live,
+        delete_saml_connection=auth.delete_saml_connection,
     )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 setup(
     name="propelauth-fastapi",
-    version="2.1.20",
+    version="2.2.0",
     description="A FastAPI library for managing authentication, backed by PropelAuth",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -21,7 +21,7 @@ setup(
     author="PropelAuth",
     author_email="support@propelauth.com",
     license="MIT",
-    install_requires=["propelauth-py==3.1.19", "requests"],
+    install_requires=["propelauth-py==3.2.0", "requests"],
     setup_requires=pytest_runner,
     tests_require=["pytest==4.4.1"],
     test_suite="tests",


### PR DESCRIPTION
depends on [this PR](https://github.com/PropelAuth/propelauth-py/pull/63) releasing first