### PR TITLE
publish a wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,9 @@ jobs:
       run: python -m pytest
 
     - name: Build a binary wheel and a source tarball
-      run: python setup.py sdist
+      run: |
+        python -m pip install build
+        python -m build
 
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Direct invocation of setup.py is deprecated.  Publish a wheel, as well as a source distribution.